### PR TITLE
Allow multiple roxie load balancers

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,6 +13,8 @@ usage()
    echo "  -p: HPCC project name: ce or ce-plugins. Default is ce"
    echo "  -s: base linux image tag suffix. The default is hpcc<major version>]."
    echo "      For xenial use hpcc6, the other use hpcc5."
+   echo "  -t: tag. By default it will use fullversion and codename"
+   echo "      It is useful to create \"latest\" tag "
    echo "  -v: full version. For example: 6.0.0-rc1 or 5.6.2-1"
    echo ""
    exit
@@ -29,7 +31,7 @@ template=
 hpcc_docker_dir=../HPCC-Docker-Ansible
 base_suffix=
 
-while getopts "*b:d:l:p:s:v:" arg
+while getopts "*b:d:l:p:s:t:v:" arg
 do
     case "$arg" in
        b) base_url="$OPTARG"
@@ -41,6 +43,8 @@ do
        p) project="$OPTARG"
           ;;
        s) base_suffix="$OPTARG"
+          ;;
+       t) tag="$OPTARG"
           ;;
        v) fullversion="$OPTARG"
           ;;
@@ -62,12 +66,12 @@ package_type
 case "$codename" in
    "el6" | "el7" )
      file_name_suffix="${fullversion}.${codename}.x86_64.rpm"
-     tag="${fullversion}.${codename}"
+     [ -z "$tag" ] && tag="${fullversion}.${codename}"
      package_type=rpm
      ;;
    "trusty" | "xenial" )
      file_name_suffix="${fullversion}${codename}_amd64.deb"
-     tag="${fullversion}${codename}"
+     [ -z "$tag" ] && tag="${fullversion}${codename}"
      package_type=deb
      ;;
     * ) echo "Unsupported codename $codename" 

--- a/hpcc-tools/ansible/setup.sh
+++ b/hpcc-tools/ansible/setup.sh
@@ -10,7 +10,7 @@ usage()
     echo "  -a <ansible config file>: If omitted the default is /etc/ansible/ansible.cfg"
     echo "  -c <cofig file>: <key>=<value> of the cluster configuration and HPCC products version, etc" 
     echo "  -d <directory>: contains node ips in files named as node types. For example,  "
-    echo "                  support, thor, roxie, etc"
+    echo "                  dali, support, thor, roxie, etc"
     echo "  -w <work dir>:  this will be ansible hosts directory. If omitted the -d value will be used"
     echo ""
     exit 1

--- a/hpcc-tools/ansible/setup.sh
+++ b/hpcc-tools/ansible/setup.sh
@@ -31,7 +31,7 @@ disable_host_key_check()
 
 add_ips_to_hosts_file()
 {
-   echo "node_type: $node_type"
+   echo "$node_type :"
    #distro_name=$(cat ${ip_files_dir}/${node_type} | head -n 1 | sed 's/[[:space:]]//g'))  
    [ -s ${ANSIBLE_HOSTS_FILE} ] && echo "" >> ${ANSIBLE_HOSTS_FILE}
    i=0  
@@ -46,7 +46,9 @@ add_ips_to_hosts_file()
        ansible_ip=$(echo $ip | sed 's/\([[:digit:]]*\)-\([[:digit:]]*\)/\[\1:\2\]/g')
        [ $i -eq 0 ] && echo "[${node_type}]" >> ${ANSIBLE_HOSTS_FILE} 
        echo "$ip" >> ${ANSIBLE_HOSTS_FILE} 
-       echo "${ip};" >>  ${HPCC_IPS_DIR}/${node_type}
+       #When input ip files ready need add ';'
+       #echo "${ip};" >>  ${HPCC_IPS_DIR}/${node_type}
+       echo "${ip}" >>  ${HPCC_IPS_DIR}/${node_type}
        i=$(expr $i \+ 1)
    done < ${ip_files_dir}/${node_type}  
    if [ $i -gt 0 ]
@@ -92,7 +94,7 @@ hosts_dir=/etc/ansible
 config_file=
 ansible_config_file=/etc/ansible/ansible.cfg
 
-while getopts "*hc:d:w:" arg
+while getopts "*ha:c:d:w:" arg
 do
     case "$arg" in
        a) ansible_config_file="$OPTARG"
@@ -117,6 +119,7 @@ fi
 [ -z "$hosts_dir" ] && hosts_dir=$ip_files_dir  
 
 disable_host_key_check
+touch ~/.ssh/known_hosts
 
 #
 # Preperation
@@ -167,7 +170,7 @@ do
 done
 
 echo "" >> ${ANSIBLE_HOSTS_FILE} 
-echo "[non-dali]" >> ${ANSIBLE_HOSTS_FILE} 
+echo "[non-dali:children]" >> ${ANSIBLE_HOSTS_FILE} 
 for node_type in $(echo ${cluster_node_types} | sed 's/,/ /g')
 do
     case "$node_type" in
@@ -177,3 +180,7 @@ do
     esac
 done
 
+echo "" >> ${ANSIBLE_HOSTS_FILE} 
+echo "[hpcc:children]" >> ${ANSIBLE_HOSTS_FILE} 
+echo "dali" >> ${ANSIBLE_HOSTS_FILE} 
+echo "non-dali" >> ${ANSIBLE_HOSTS_FILE} 

--- a/hpcc-tools/ansible/start_hpcc.yaml
+++ b/hpcc-tools/ansible/start_hpcc.yaml
@@ -1,9 +1,10 @@
-# run as ansible-playbook start_hpcc.yaml --extra-vars "hosts=dali user=hpcc" 
-# run as ansible-playbook start_hpcc.yaml --extra-vars "hosts=non-dali user=hpcc" 
+# run as ansible-playbook start_hpcc.yaml --extra-vars "hosts=dali" 
+# run as ansible-playbook start_hpcc.yaml --extra-vars "hosts=non-dali" 
+# run as ansible-playbook start_hpcc.yaml --extra-vars "hosts=hpcc" 
 ---
 - name: Execute a script.
   hosts: '{{ hosts }}'
-  remote_user: '{{ user }}'
+  remote_user: 'root'
   tasks:
      - name: Execute the script
        command: bash /etc/init.d/hpcc-init start

--- a/hpcc-tools/ansible/stop_hpcc.yaml
+++ b/hpcc-tools/ansible/stop_hpcc.yaml
@@ -1,9 +1,10 @@
-# run as ansible-playbook stop_hpcc.yaml --extra-vars "hosts=dali user=hpcc" 
-# run as ansible-playbook stop_hpcc.yaml --extra-vars "hosts=non-dali user=hpcc" 
+# run as ansible-playbook stop_hpcc.yaml --extra-vars "hosts=dali" 
+# run as ansible-playbook stop_hpcc.yaml --extra-vars "hosts=non-dali" 
+# run as ansible-playbook stop_hpcc.yaml --extra-vars "hosts=hpcc" 
 ---
 - name: Execute a script.
   hosts: '{{ hosts }}'
-  remote_user: '{{ user }}'
+  remote_user: 'root'
   tasks:
      - name: Execute the script
        command: bash /etc/init.d/hpcc-init stop

--- a/hpcc-tools/config_hpcc.sh
+++ b/hpcc-tools/config_hpcc.sh
@@ -9,8 +9,45 @@ function create_ips_string()
    while read ip
    do
       ip=$(echo $ip | sed 's/[[:space:]]//g') 
-      [ -n "$ip" ] && IPS="${IPS}${ip}\;"
+      [ -n "$ip" ] && IPS="${IPS}${ip}\\;"
    done < $1
+}
+
+function create_envxml()
+{
+   [ -e ${roxie_ips} ] && roxie_nodes=$(cat ${roxie_ips} | wc -l)
+   [ -e ${esp_ips} ] && esp_nodes=$(cat ${esp_ips} | wc -l)
+   [ -z "$roxie_nodes" ] && roxie_nodes=0
+   [ -z "$esp_nodes" ] && esp_nodes=0
+
+   cmd="$SUDOCMD ${HPCC_HOME}/sbin/envgen -env ${CONFIG_DIR}/${ENV_XML_FILE}   \
+       -override roxie,@roxieMulticastEnabled,false -override thor,@replicateOutputs,true \
+       -override esp,@method,htpasswd -override thor,@replicateAsync,true                 \
+       -thornodes ${thor_nodes} -slavesPerNode ${slaves_per_node} -espnodes ${esp_nodes}  \
+       -roxienodes ${roxie_nodes} -supportnodes ${support_nodes} -roxieondemand 1" 
+
+    cmd="$cmd -ip $dali_ip" 
+    if [ $thor_nodes -gt 0 ]
+    then
+       create_ips_string ${thor_ips}
+       cmd="$cmd -assign_ips thor ${dali_ip}\;${IPS}"
+    fi
+
+    if [ $roxie_nodes -gt 0 ]
+    then
+       create_ips_string ${roxie_ips}
+       cmd="$cmd -assign_ips roxie $IPS"
+    fi
+
+    if [ $esp_nodes -gt 0 ]
+    then
+       create_ips_string ${esp_ips}
+       cmd="$cmd -assign_ips esp $IPS"
+    fi
+
+    echo "$cmd" 
+    eval "$cmd"
+
 }
 
 #------------------------------------------
@@ -53,90 +90,109 @@ then
 fi
 
 #------------------------------------------
+# Create HPCC components file
+#
+hpcc_config=$(ls /tmp/ips | tr '\n' ',')
+echo "cluster_node_types=${hpcc_config%,}" > /tmp/hpcc.conf
+
+#------------------------------------------
 # Setup Ansible hosts
 #
-${SCRIPT_DIR}/ansible/setup.sh -d /tmp/ips
+${SCRIPT_DIR}/ansible/setup.sh -d /tmp/ips -c /tmp/hpcc.conf
+export ANSIBLE_HOST_KEY_CHECKING=False
 
+
+dali_ip=$(cat /etc/ansible/ips/dali)
 thor_ips=/etc/ansible/ips/thor
-roxie_ips=/etc/ansible/ips/roxie
-esp_ips=/etc/ansible/ips/esp
-dali_ip=/etc/ansible/ips/dali
 
 #------------------------------------------
 # Restore HPCC configuration files /etc/HPCCSystems
 # which is NFS share
 #
 if [ ! -e /etc/HPCCSystems/environment.conf ]; then
-   cp -r /etc/HPCCSystems.kb/* /etc/HPCCSystems/ 
+   cp -r /etc/HPCCSystems.bk/* /etc/HPCCSystems/ 
    chown -R hpcc:hpcc /etc/HPCCSystems/
 fi
+
+if [ ! -e /etc/HPCCSystems_Roxie/environment.conf ]; then
+   cp -r /etc/HPCCSystems.bk/* /etc/HPCCSystems_Roxie/ 
+   chown -R hpcc:hpcc /etc/HPCCSystems_Roxie
+fi
+
+if [ ! -e /etc/HPCCSystems_Esp/environment.conf ]; then
+   cp -r /etc/HPCCSystems.bk/* /etc/HPCCSystems_Esp/ 
+   chown -R hpcc:hpcc /etc/HPCCSystems_Esp
+fi
+
+
+#------------------------------------------
+# Stop HPCC on all nodes
+#
+ansible-playbook /opt/hpcc-tools/ansible/stop_hpcc.yaml --extra-vars "hosts=non-dali" 
+ansible-playbook /opt/hpcc-tools/ansible/stop_hpcc.yaml --extra-vars "hosts=dali" 
 
 
 #------------------------------------------
 # Parameters to envgen
 #
 HPCC_HOME=/opt/HPCCSystems
-CONFIG_DIR=/etc/HPCCSystems
 ENV_XML_FILE=environment.xml
 
 
 [ -e ${thor_ips} ] && thor_nodes=$(cat ${thor_ips} | wc -l)
-[ -e ${roxie_ips} ] && roxie_nodes=$(cat ${roxie_ips} | wc -l)
-[ -e ${esp_ips} ] && esp_nodes=$(cat ${esp_ips} | wc -l)
 support_nodes=1
 slaves_per_node=1
 [ -n "$SLAVES_PER_NODE" ] && slaves_per_node=${SLAVES_PER_NODE}
 [ -z "$thor_nodes" ] && thor_nodes=0
-[ -z "$roxie_nodes" ] && roxie_nodes=0
-[ -z "$esp_nodes" ] && esp_nodes=0
 
+#------------------------------------------
+# Get load balancer ips for roxie and esp
+#
+lb_ips=/etc/ansible/lb-ips 
+[ ! -d ${lb_ips} ] && cp -r  /etc/ansible/ips $lb_ips 
+[ -e ${lb_ips}/roxie ] && [ -n "$ROXIE_SERVICE_HOST" ] && echo  ${ROXIE_SERVICE_HOST} > ${lb_ips}/roxie
+[ -e ${lb_ips}/esp ] && [ -n "$ESP_SERVICE_HOST" ] && echo  ${ESP_SERVICE_HOST} > ${lb_ips}/esp
 
-cmd="$SUDOCMD ${HPCC_HOME}/sbin/envgen -env ${CONFIG_DIR}/${ENV_XML_FILE}   \
--override roxie,@roxieMulticastEnabled,false -override thor,@replicateOutputs,true \
--override esp,@method,htpasswd -override thor,@replicateAsync,true                  \
--thornodes ${thor_nodes} -slavesPerNode ${slaves_per_node} -espnodes ${esp_nodes}       \
--roxienodes ${roxie_nodes} -supportnodes ${support_nodes} -roxieondemand 1" 
+#------------------------------------------
+# Generate environment for all nodes with
+# roxie and esp load balancer ips
+#
+CONFIG_DIR=/etc/HPCCSystems
+roxie_ips=${lb_ips}/roxie
+esp_ips=${lb_ips}/esp
+create_envxml
+chown -R hpcc:hpcc $CONFIG_DIR
 
-HPCC_VERSION=$(${HPCC_HOME}/bin/eclcc --version | cut -d' ' -f1)
-HPCC_MAJOR=${HPCC_VERSION%%.*}
-dali_ip=$(cat ${dali_ip})
-if [ $HPCC_MAJOR -gt 5 ]
-then
-    cmd="$cmd -ip $dali_ip" 
-    if [ $thor_nodes -gt 0 ]
-    then
-       create_ips_string ${thor_ips}
-       cmd="$cmd -assign_ips thor ${dali_ip}\;${IPS}"
-    fi
+#------------------------------------------
+# Generate environment for all real ips
+#
+esp_ips=/etc/ansible/ips/esp
+roxie_ips=/etc/ansible/ips/roxie
+CONFIG_DIR=/etc/HPCCSystems/real
+[ ! -d $CONFIG_DIR ] && cp -r /etc/HPCCSystems.bk $CONFIG_DIR
+create_envxml
+chown -R hpcc:hpcc $CONFIG_DIR
+CONFIG_DIR=/etc/HPCCSystems
 
-    if [ $roxie_nodes -gt 0 ]
-    then
-       create_ips_string ${roxie_ips}
-       cmd="$cmd -assign_ips roxie $IPS"
-    fi
-
-    if [ $esp_nodes -gt 0 ]
-    then
-       create_ips_string ${esp_ips}
-       cmd="$cmd -assign_ips esp $IPS"
-    fi
-else
-    echo "Must HPCC 6.0.4 and later"
-    return 1
+#------------------------------------------
+# Createe environment roxie
+#
+CONFIG_DIR=/etc/HPCCSystems_Roxie
+cp -r /etc/HPCCSystems/* ${CONFIG_DIR}/
+if [ -n "$ROXIE_SERVICE_HOST" ]; then
+  sed  "s/${ROXIE_SERVICE_HOST}/localhost/g"  /etc/HPCCSystems/environment.xml > ${CONFIG_DIR}/environment.xml
 fi
+chown -R hpcc:hpcc $CONFIG_DIR
 
 #------------------------------------------
-# Generate environment.xml
+# Createe environment esp
 #
-echo "$cmd" 
-eval "$cmd"
-
-#------------------------------------------
-# Transfer environment.xml to cluster 
-# containers
-#
-#$SUDOCMD   su - hpcc -c "/opt/HPCCSystems/sbin/hpcc-push.sh \
-#-s /etc/HPCCSystems/environment.xml -t /etc/HPCCSystems/environment.xml -x"
+CONFIG_DIR=/etc/HPCCSystems_Esp
+cp -r /etc/HPCCSystems/* ${CONFIG_DIR}/
+if [ -n "$ESP_SERVICE_HOST" ]; then
+  sed  "s/${ESP_SERVICE_HOST}/localhost/g"  /etc/HPCCSystems/environment.xml > ${CONFIG_DIR}/environment.xml
+fi
+chown -R hpcc:hpcc $CONFIG_DIR
 
 #------------------------------------------
 # Start hpcc 
@@ -147,6 +203,9 @@ eval "$cmd"
 # Force them to read environemnt.xml by stop and start
 #$SUDOCMD su - hpcc -c  "${HPCC_HOME}/sbin/hpcc-run.sh stop"
 #$SUDOCMD su - hpcc -c  "${HPCC_HOME}/sbin/hpcc-run.sh start"
+
+ansible-playbook /opt/hpcc-tools/ansible/start_hpcc.yaml --extra-vars "hosts=dali" 
+ansible-playbook /opt/hpcc-tools/ansible/start_hpcc.yaml --extra-vars "hosts=non-dali" 
 
 
 

--- a/hpcc-tools/config_hpcc.sh
+++ b/hpcc-tools/config_hpcc.sh
@@ -102,6 +102,9 @@ ${SCRIPT_DIR}/ansible/setup.sh -d /tmp/ips -c /tmp/hpcc.conf
 export ANSIBLE_HOST_KEY_CHECKING=False
 
 
+[ "$1" = "setup" ] && exit 0 
+
+
 dali_ip=$(cat /etc/ansible/ips/dali)
 thor_ips=/etc/ansible/ips/thor
 

--- a/hpcc-tools/get_ips.py
+++ b/hpcc-tools/get_ips.py
@@ -14,6 +14,7 @@ roxie_ips_file = "roxie_ips.txt"
 f_ips = open ('ips.txt', 'w')
 f_roxie_ips = open ('roxie_ips.txt', 'w')
 f_thor_ips = open ('thor_ips.txt', 'w')
+f_esp_ips = open ('esp_ips.txt', 'w')
 for item in data['items']:
    #for c in  item['spec']['containers']:
    #   print c['name']
@@ -22,6 +23,8 @@ for item in data['items']:
      f_roxie_ips.write(item['status']['podIP'] + "\n")
    elif item['metadata']['name'].startswith('thor'):
      f_thor_ips.write(item['status']['podIP'] + "\n")
+   elif item['metadata']['name'].startswith('esp'):
+     f_esp_ips.write(item['status']['podIP'] + "\n")
    elif item['metadata']['name'].startswith('master'):
      f_ips.write(item['status']['podIP'] + "\n")
 

--- a/hpcc-tools/get_ips.py
+++ b/hpcc-tools/get_ips.py
@@ -5,7 +5,7 @@ import json
 if len(sys.argv) > 1:
    fn = sys.argv[1]
 else:
-   fn = "pods.json"
+   fn = "/tmp/pods.json"
 
 with open(fn) as hpcc_pods:
     data = json.load(hpcc_pods)

--- a/hpcc-tools/get_ips.py
+++ b/hpcc-tools/get_ips.py
@@ -11,10 +11,10 @@ with open(fn) as hpcc_pods:
     data = json.load(hpcc_pods)
 
 roxie_ips_file = "roxie_ips.txt"
-f_ips = open ('ips.txt', 'w')
-f_roxie_ips = open ('roxie_ips.txt', 'w')
-f_thor_ips = open ('thor_ips.txt', 'w')
-f_esp_ips = open ('esp_ips.txt', 'w')
+f_dali_ips = open ('/tmp/ips/dali', 'w')
+f_roxie_ips = open ('/tmp/ips/roxie', 'w')
+f_thor_ips = open ('/tmp/ips/thor', 'w')
+f_esp_ips = open ('/tmp/ips/esp', 'w')
 for item in data['items']:
    #for c in  item['spec']['containers']:
    #   print c['name']
@@ -25,10 +25,11 @@ for item in data['items']:
      f_thor_ips.write(item['status']['podIP'] + "\n")
    elif item['metadata']['name'].startswith('esp'):
      f_esp_ips.write(item['status']['podIP'] + "\n")
-   elif item['metadata']['name'].startswith('master'):
-     f_ips.write(item['status']['podIP'] + "\n")
+   elif item['metadata']['name'].startswith('dali'):
+     f_dali_ips.write(item['status']['podIP'] + "\n")
 
 
-f_ips.close()
+f_dali_ips.close()
 f_roxie_ips.close()
 f_thor_ips.close()
+f_esp_ips.close()

--- a/hpcc-tools/get_ips.sh
+++ b/hpcc-tools/get_ips.sh
@@ -2,4 +2,6 @@
 
 KUBE_TOKEN=$(</var/run/secrets/kubernetes.io/serviceaccount/token)
 wget --no-check-certificate --header="Authorization: Bearer $KUBE_TOKEN"  \
- https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT/api/v1/pods  -O pods.json
+ https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT/api/v1/pods  -O /tmp/pods.json
+
+[ ! -d /tmp/ips ] && mkdir -p /tmp/ips

--- a/hpcc/trusty/Dockerfile.template.ce
+++ b/hpcc/trusty/Dockerfile.template.ce
@@ -13,6 +13,6 @@ RUN cp -r /etc/HPCCSystems /etc/HPCCSystems.bk
 ADD hpcc-tools /opt/hpcc-tools
 RUN chmod +x /opt/hpcc-tools/*.sh
 RUN chmod +x /opt/hpcc-tools/*.py
-RUN mkdir -p /var/run/sshd
 RUN cp -r /home/hpcc/.ssh ~/
+RUN mkdir -p /var/run/sshd
 CMD ["bash", "-c", "set -e && sudo /usr/sbin/sshd -D"]

--- a/hpcc/trusty/Dockerfile.template.ce
+++ b/hpcc/trusty/Dockerfile.template.ce
@@ -9,6 +9,7 @@ RUN wget <URL_BASE>/<PLATFORM_TYPE>-Candidate-<VERSION>/bin/platform/hpccsystems
 RUN groupadd hpcc
 RUN useradd -s /bin/bash -r -m -d /home/hpcc -g hpcc -c "hpcc Runtime User" hpcc
 RUN dpkg -i hpccsystems-platform-community_<FILE_NAME_SUFFIX>
+RUN cp -r /etc/HPCCSystems /etc/HPCCSystems.bk
 ADD hpcc-tools /opt/hpcc-tools
 RUN chmod +x /opt/hpcc-tools/*.sh
 RUN chmod +x /opt/hpcc-tools/*.py

--- a/hpcc/trusty/Dockerfile.template.ce
+++ b/hpcc/trusty/Dockerfile.template.ce
@@ -14,4 +14,5 @@ ADD hpcc-tools /opt/hpcc-tools
 RUN chmod +x /opt/hpcc-tools/*.sh
 RUN chmod +x /opt/hpcc-tools/*.py
 RUN mkdir -p /var/run/sshd
+RUN cp -r /home/hpcc/.ssh ~/
 CMD ["bash", "-c", "set -e && sudo /usr/sbin/sshd -D"]


### PR DESCRIPTION
Add environment variable NUM_ROXIE_LB. config_hpcc.sh will base on this value to collect roxie load balancers for generating environment.xml. If NUM_ROXIE_LB is 0 real roxie ips will be used instead.

Allow build tag "latest" so Kubernetes will already fetch the latest docker image.